### PR TITLE
Integrate SQLAlchemy for database persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.env
+*.pyc
+__pycache__/
+sql_app.db

--- a/database.py
+++ b/database.py
@@ -1,0 +1,37 @@
+from sqlalchemy import create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+import os
+from dotenv import load_dotenv
+
+load_dotenv() # Carrega variáveis do .env
+
+# Para desenvolvimento inicial, usaremos SQLite.
+# DATABASE_URL = "sqlite:///./test.db"
+
+# Para PostgreSQL, descomente a linha abaixo e configure o .env
+# DATABASE_URL = os.getenv("DATABASE_URL")
+
+# Remova esta linha quando for usar PostgreSQL de fato e configure o .env
+DATABASE_URL = "sqlite:///./sql_app.db"
+
+
+if DATABASE_URL is None:
+    raise EnvironmentError("DATABASE_URL não foi definida nas variáveis de ambiente.")
+
+engine = create_engine(
+    DATABASE_URL,
+    # A flag connect_args é específica para SQLite. Não será necessária para PostgreSQL.
+    connect_args={"check_same_thread": False} if "sqlite" in DATABASE_URL else {}
+)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()
+
+# Função para obter uma sessão de banco de dados
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/main.py
+++ b/main.py
@@ -1,161 +1,223 @@
 from typing import List, Optional
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Depends # Added Depends
 from pydantic import EmailStr
+from datetime import date
 
-from datetime import date # Added
-from typing import List, Optional
+# Database imports
+from database import engine, SessionLocal, get_db # Adicionado get_db
+from sqlalchemy.orm import Session # Adicionado Session
 
-from fastapi import FastAPI, HTTPException
-from pydantic import EmailStr
+# Model imports
+from models.lawyer import Lawyer, LawyerCreate # Pydantic models
+from models.client import Client, ClientCreate # Pydantic models
+from models.legal_process import LegalProcess, LegalProcessCreate, LegalProcessBase # Pydantic models
 
-# Assuming models are in a directory named 'models'
-from models.lawyer import Lawyer, LawyerCreate
-from models.client import Client, ClientCreate
-from models.legal_process import LegalProcess, LegalProcessCreate, LegalProcessBase # Added
+from models import lawyer as lawyer_model
+from models import client as client_model
+from models import legal_process as process_model
 
 app = FastAPI()
 
-db_lawyers: List[Lawyer] = []
-lawyer_id_counter = 0
+# Criar tabelas do banco de dados
+lawyer_model.Base.metadata.create_all(bind=engine)
+client_model.Base.metadata.create_all(bind=engine)
+process_model.Base.metadata.create_all(bind=engine)
 
-db_clients: List[Client] = []
-client_id_counter = 0
-
-db_legal_processes: List[LegalProcess] = [] # Added
-process_id_counter = 0 # Added
-
-# Helper functions to check existence
-def get_lawyer_by_id(lawyer_id: int) -> Optional[Lawyer]:
-    for lawyer in db_lawyers:
-        if lawyer.id == lawyer_id:
-            return lawyer
-    return None
-
-def get_client_by_id(client_id: int) -> Optional[Client]:
-    for client in db_clients:
-        if client.id == client_id:
-            return client
-    return None
-
+# As funções auxiliares get_lawyer_by_id e get_client_by_id foram removidas.
+# A lógica de verificação de existência de advogado/cliente
+# já está integrada nos endpoints de LegalProcess.
 
 @app.post("/lawyers/", response_model=Lawyer)
-def create_lawyer(lawyer_in: LawyerCreate):
-    global lawyer_id_counter
-    lawyer_id_counter += 1
-    new_lawyer = Lawyer(id=lawyer_id_counter, **lawyer_in.model_dump())
-    db_lawyers.append(new_lawyer)
-    return new_lawyer
+def create_lawyer(lawyer_in: LawyerCreate, db: Session = Depends(get_db)):
+    # global lawyer_id_counter # Removido
+    # lawyer_id_counter += 1 # Removido
+    # new_lawyer = Lawyer(id=lawyer_id_counter, **lawyer_in.model_dump()) # Removido
+    # db_lawyers.append(new_lawyer) # Removido
+    db_lawyer = lawyer_model.LawyerDB(**lawyer_in.model_dump())
+    db.add(db_lawyer)
+    db.commit()
+    db.refresh(db_lawyer)
+    return db_lawyer
 
 @app.get("/lawyers/", response_model=List[Lawyer])
-def get_lawyers(name: Optional[str] = None, oab: Optional[str] = None):
-    filtered_lawyers = db_lawyers
+def get_lawyers(name: Optional[str] = None, oab: Optional[str] = None, db: Session = Depends(get_db)): # Adicionado db
+    # filtered_lawyers = db_lawyers # Removido
+    query = db.query(lawyer_model.LawyerDB)
     if name:
-        filtered_lawyers = [
-            lawyer for lawyer in filtered_lawyers if name.lower() in lawyer.name.lower()
-        ]
+        # filtered_lawyers = [
+        #     lawyer for lawyer in filtered_lawyers if name.lower() in lawyer.name.lower()
+        # ]
+        query = query.filter(lawyer_model.LawyerDB.name.contains(name))
     if oab:
-        filtered_lawyers = [
-            lawyer for lawyer in filtered_lawyers if lawyer.oab == oab
-        ]
-    return filtered_lawyers
+        # filtered_lawyers = [
+        #     lawyer for lawyer in filtered_lawyers if lawyer.oab == oab
+        # ]
+        query = query.filter(lawyer_model.LawyerDB.oab == oab)
+    # return filtered_lawyers
+    return query.all()
 
 @app.get("/lawyers/{lawyer_id}", response_model=Lawyer)
-def get_lawyer(lawyer_id: int):
-    for lawyer in db_lawyers:
-        if lawyer.id == lawyer_id:
-            return lawyer
-    raise HTTPException(status_code=404, detail="Lawyer not found")
+def get_lawyer(lawyer_id: int, db: Session = Depends(get_db)): # Adicionado db
+    # for lawyer in db_lawyers: # Removido
+    #     if lawyer.id == lawyer_id: # Removido
+    #         return lawyer # Removido
+    db_lawyer = db.query(lawyer_model.LawyerDB).filter(lawyer_model.LawyerDB.id == lawyer_id).first()
+    if db_lawyer is None:
+        raise HTTPException(status_code=404, detail="Lawyer not found")
+    return db_lawyer
 
 @app.put("/lawyers/{lawyer_id}", response_model=Lawyer)
-def update_lawyer(lawyer_id: int, lawyer_update: LawyerCreate):
-    for index, lawyer in enumerate(db_lawyers):
-        if lawyer.id == lawyer_id:
-            updated_lawyer = lawyer.model_copy(update=lawyer_update.model_dump(exclude_unset=True))
-            db_lawyers[index] = updated_lawyer
-            return updated_lawyer
-    raise HTTPException(status_code=404, detail="Lawyer not found")
+def update_lawyer(lawyer_id: int, lawyer_update: LawyerCreate, db: Session = Depends(get_db)): # Adicionado db
+    # for index, lawyer in enumerate(db_lawyers): # Removido
+    #     if lawyer.id == lawyer_id: # Removido
+    #         updated_lawyer = lawyer.model_copy(update=lawyer_update.model_dump(exclude_unset=True)) # Removido
+    #         db_lawyers[index] = updated_lawyer # Removido
+    #         return updated_lawyer # Removido
+    db_lawyer = db.query(lawyer_model.LawyerDB).filter(lawyer_model.LawyerDB.id == lawyer_id).first()
+    if db_lawyer is None:
+        raise HTTPException(status_code=404, detail="Lawyer not found")
+
+    update_data = lawyer_update.model_dump(exclude_unset=True)
+    for key, value in update_data.items():
+        setattr(db_lawyer, key, value)
+
+    db.add(db_lawyer)
+    db.commit()
+    db.refresh(db_lawyer)
+    return db_lawyer
 
 @app.delete("/lawyers/{lawyer_id}")
-def delete_lawyer(lawyer_id: int):
+def delete_lawyer(lawyer_id: int, db: Session = Depends(get_db)): # Adicionado db
     # Check if lawyer is associated with any legal processes
-    for process in db_legal_processes:
-        if process.lawyer_id == lawyer_id:
-            raise HTTPException(
-                status_code=400,
-                detail="Lawyer cannot be deleted as they are associated with one or more legal processes."
-            )
+    # for process in db_legal_processes: # Removido - esta lógica será reimplementada
+    #     if process.lawyer_id == lawyer_id:
+    #         raise HTTPException(
+    #             status_code=400,
+    #             detail="Lawyer cannot be deleted as they are associated with one or more legal processes."
+    #         )
+    db_lawyer = db.query(lawyer_model.LawyerDB).filter(lawyer_model.LawyerDB.id == lawyer_id).first()
+    if db_lawyer is None:
+        raise HTTPException(status_code=404, detail="Lawyer not found")
 
-    for index, lawyer in enumerate(db_lawyers):
-        if lawyer.id == lawyer_id:
-            db_lawyers.pop(index)
-            return {"message": "Lawyer deleted successfully"}
-    raise HTTPException(status_code=404, detail="Lawyer not found")
+    # Verificar processos associados (simplificado por agora, pode precisar de lógica mais robusta)
+    associated_processes = db.query(process_model.LegalProcessDB).filter(process_model.LegalProcessDB.lawyer_id == lawyer_id).count()
+    if associated_processes > 0:
+        raise HTTPException(
+            status_code=400,
+            detail="Lawyer cannot be deleted as they are associated with one or more legal processes."
+        )
+
+    # for index, lawyer in enumerate(db_lawyers): # Removido
+    #     if lawyer.id == lawyer_id: # Removido
+    #         db_lawyers.pop(index) # Removido
+    #         return {"message": "Lawyer deleted successfully"} # Removido
+    db.delete(db_lawyer)
+    db.commit()
+    return {"message": "Lawyer deleted successfully"}
 
 
 # CRUD Endpoints for Clients
 
 @app.post("/clients/", response_model=Client)
-def create_client(client_in: ClientCreate):
-    global client_id_counter
-    client_id_counter += 1
-    new_client = Client(id=client_id_counter, **client_in.model_dump())
-    db_clients.append(new_client)
-    return new_client
+def create_client(client_in: ClientCreate, db: Session = Depends(get_db)): # Adicionado db
+    # global client_id_counter # Removido
+    # client_id_counter += 1 # Removido
+    # new_client = Client(id=client_id_counter, **client_in.model_dump()) # Removido
+    # db_clients.append(new_client) # Removido
+    db_client = client_model.ClientDB(**client_in.model_dump())
+    db.add(db_client)
+    db.commit()
+    db.refresh(db_client)
+    return db_client
 
 @app.get("/clients/", response_model=List[Client])
-def get_clients():
-    return db_clients
+def get_clients(db: Session = Depends(get_db)): # Adicionado db
+    # return db_clients # Removido
+    return db.query(client_model.ClientDB).all()
 
 @app.get("/clients/{client_id}", response_model=Client)
-def get_client(client_id: int):
-    for client in db_clients:
-        if client.id == client_id:
-            return client
-    raise HTTPException(status_code=404, detail="Client not found")
+def get_client(client_id: int, db: Session = Depends(get_db)): # Adicionado db
+    # for client in db_clients: # Removido
+    #     if client.id == client_id: # Removido
+    #         return client # Removido
+    db_client = db.query(client_model.ClientDB).filter(client_model.ClientDB.id == client_id).first()
+    if db_client is None:
+        raise HTTPException(status_code=404, detail="Client not found")
+    return db_client
 
 @app.put("/clients/{client_id}", response_model=Client)
-def update_client(client_id: int, client_update: ClientCreate):
-    for index, client in enumerate(db_clients):
-        if client.id == client_id:
-            updated_client = client.model_copy(update=client_update.model_dump(exclude_unset=True))
-            db_clients[index] = updated_client
-            return updated_client
-    raise HTTPException(status_code=404, detail="Client not found")
+def update_client(client_id: int, client_update: ClientCreate, db: Session = Depends(get_db)): # Adicionado db
+    # for index, client in enumerate(db_clients): # Removido
+    #     if client.id == client_id: # Removido
+    #         updated_client = client.model_copy(update=client_update.model_dump(exclude_unset=True)) # Removido
+    #         db_clients[index] = updated_client # Removido
+    #         return updated_client # Removido
+    db_client = db.query(client_model.ClientDB).filter(client_model.ClientDB.id == client_id).first()
+    if db_client is None:
+        raise HTTPException(status_code=404, detail="Client not found")
+
+    update_data = client_update.model_dump(exclude_unset=True)
+    for key, value in update_data.items():
+        setattr(db_client, key, value)
+
+    db.add(db_client)
+    db.commit()
+    db.refresh(db_client)
+    return db_client
 
 @app.delete("/clients/{client_id}")
-def delete_client(client_id: int):
+def delete_client(client_id: int, db: Session = Depends(get_db)): # Adicionado db
     # Check if client is associated with any legal processes
-    for process in db_legal_processes:
-        if process.client_id == client_id:
-            raise HTTPException(
-                status_code=400,
-                detail="Client cannot be deleted as they are associated with one or more legal processes."
-            )
+    # for process in db_legal_processes: # Removido - esta lógica será reimplementada
+    #     if process.client_id == client_id:
+    #         raise HTTPException(
+    #             status_code=400,
+    #             detail="Client cannot be deleted as they are associated with one or more legal processes."
+    #         )
+    db_client = db.query(client_model.ClientDB).filter(client_model.ClientDB.id == client_id).first()
+    if db_client is None:
+        raise HTTPException(status_code=404, detail="Client not found")
 
-    for index, client in enumerate(db_clients):
-        if client.id == client_id:
-            db_clients.pop(index)
-            return {"message": "Client deleted successfully"}
-    raise HTTPException(status_code=404, detail="Client not found")
+    # Verificar processos associados (simplificado por agora, pode precisar de lógica mais robusta)
+    associated_processes = db.query(process_model.LegalProcessDB).filter(process_model.LegalProcessDB.client_id == client_id).count()
+    if associated_processes > 0:
+        raise HTTPException(
+            status_code=400,
+            detail="Client cannot be deleted as they are associated with one or more legal processes."
+        )
+
+    # for index, client in enumerate(db_clients): # Removido
+    #     if client.id == client_id: # Removido
+    #         db_clients.pop(index) # Removido
+    #         return {"message": "Client deleted successfully"} # Removido
+    db.delete(db_client)
+    db.commit()
+    return {"message": "Client deleted successfully"}
 
 
 # CRUD Endpoints for Legal Processes
 
 @app.post("/processes/", response_model=LegalProcess)
-def create_legal_process(process_in: LegalProcessCreate):
-    global process_id_counter
+def create_legal_process(process_in: LegalProcessCreate, db: Session = Depends(get_db)): # Adicionado db
+    # global process_id_counter # Removido
     # Validate lawyer_id
-    if not get_lawyer_by_id(process_in.lawyer_id):
+    lawyer = db.query(lawyer_model.LawyerDB).filter(lawyer_model.LawyerDB.id == process_in.lawyer_id).first()
+    if not lawyer:
         raise HTTPException(status_code=404, detail=f"Lawyer with id {process_in.lawyer_id} not found")
     # Validate client_id
-    if not get_client_by_id(process_in.client_id):
+    client = db.query(client_model.ClientDB).filter(client_model.ClientDB.id == process_in.client_id).first()
+    if not client:
         raise HTTPException(status_code=404, detail=f"Client with id {process_in.client_id} not found")
 
-    process_id_counter += 1
-    new_process = LegalProcess(id=process_id_counter, **process_in.model_dump())
-    db_legal_processes.append(new_process)
-    return new_process
+    # process_id_counter += 1 # Removido
+    # new_process = LegalProcess(id=process_id_counter, **process_in.model_dump()) # Removido
+    # db_legal_processes.append(new_process) # Removido
+    db_process = process_model.LegalProcessDB(**process_in.model_dump())
+    db.add(db_process)
+    db.commit()
+    db.refresh(db_process)
+    return db_process
 
 @app.get("/processes/", response_model=List[LegalProcess])
 def get_legal_processes(
@@ -163,49 +225,79 @@ def get_legal_processes(
     lawyer_id: Optional[int] = None,
     action_type: Optional[str] = None,
     status: Optional[str] = None,
+    db: Session = Depends(get_db) # Adicionado db
 ):
-    filtered_processes = db_legal_processes
+    # filtered_processes = db_legal_processes # Removido
+    query = db.query(process_model.LegalProcessDB)
     if client_id is not None:
-        filtered_processes = [p for p in filtered_processes if p.client_id == client_id]
+        # filtered_processes = [p for p in filtered_processes if p.client_id == client_id]
+        query = query.filter(process_model.LegalProcessDB.client_id == client_id)
     if lawyer_id is not None:
-        filtered_processes = [p for p in filtered_processes if p.lawyer_id == lawyer_id]
+        # filtered_processes = [p for p in filtered_processes if p.lawyer_id == lawyer_id]
+        query = query.filter(process_model.LegalProcessDB.lawyer_id == lawyer_id)
     if action_type:
-        filtered_processes = [
-            p for p in filtered_processes if p.action_type and action_type.lower() in p.action_type.lower()
-        ]
+        # filtered_processes = [
+        #     p for p in filtered_processes if p.action_type and action_type.lower() in p.action_type.lower()
+        # ]
+        query = query.filter(process_model.LegalProcessDB.action_type.contains(action_type))
     if status:
-        filtered_processes = [
-            p for p in filtered_processes if p.status and status.lower() == p.status.lower()
-        ]
-    return filtered_processes
+        # filtered_processes = [
+        #     p for p in filtered_processes if p.status and status.lower() == p.status.lower()
+        # ]
+        query = query.filter(process_model.LegalProcessDB.status == status)
+    # return filtered_processes
+    return query.all()
 
 @app.get("/processes/{process_id}", response_model=LegalProcess)
-def get_legal_process(process_id: int):
-    for process in db_legal_processes:
-        if process.id == process_id:
-            return process
-    raise HTTPException(status_code=404, detail="Legal process not found")
+def get_legal_process(process_id: int, db: Session = Depends(get_db)): # Adicionado db
+    # for process in db_legal_processes: # Removido
+    #     if process.id == process_id: # Removido
+    #         return process # Removido
+    db_process = db.query(process_model.LegalProcessDB).filter(process_model.LegalProcessDB.id == process_id).first()
+    if db_process is None:
+        raise HTTPException(status_code=404, detail="Legal process not found")
+    return db_process
 
 @app.put("/processes/{process_id}", response_model=LegalProcess)
-def update_legal_process(process_id: int, process_update: LegalProcessCreate):
-    for index, process in enumerate(db_legal_processes):
-        if process.id == process_id:
+def update_legal_process(process_id: int, process_update: LegalProcessCreate, db: Session = Depends(get_db)): # Adicionado db
+    # for index, process in enumerate(db_legal_processes): # Removido
+    #     if process.id == process_id: # Removido
             # Validate lawyer_id if updated
-            if process_update.lawyer_id != process.lawyer_id and not get_lawyer_by_id(process_update.lawyer_id):
-                raise HTTPException(status_code=404, detail=f"Lawyer with id {process_update.lawyer_id} not found")
-            # Validate client_id if updated
-            if process_update.client_id != process.client_id and not get_client_by_id(process_update.client_id):
-                raise HTTPException(status_code=404, detail=f"Client with id {process_update.client_id} not found")
+    db_process = db.query(process_model.LegalProcessDB).filter(process_model.LegalProcessDB.id == process_id).first()
+    if db_process is None:
+        raise HTTPException(status_code=404, detail="Legal process not found")
 
-            updated_process = process.model_copy(update=process_update.model_dump(exclude_unset=True))
-            db_legal_processes[index] = updated_process
-            return updated_process
-    raise HTTPException(status_code=404, detail="Legal process not found")
+    if process_update.lawyer_id != db_process.lawyer_id:
+        lawyer = db.query(lawyer_model.LawyerDB).filter(lawyer_model.LawyerDB.id == process_update.lawyer_id).first()
+        if not lawyer:
+            raise HTTPException(status_code=404, detail=f"Lawyer with id {process_update.lawyer_id} not found")
+    # Validate client_id if updated
+    if process_update.client_id != db_process.client_id:
+        client = db.query(client_model.ClientDB).filter(client_model.ClientDB.id == process_update.client_id).first()
+        if not client:
+            raise HTTPException(status_code=404, detail=f"Client with id {process_update.client_id} not found")
+
+            # updated_process = process.model_copy(update=process_update.model_dump(exclude_unset=True)) # Removido
+            # db_legal_processes[index] = updated_process # Removido
+            # return updated_process # Removido
+    update_data = process_update.model_dump(exclude_unset=True)
+    for key, value in update_data.items():
+        setattr(db_process, key, value)
+
+    db.add(db_process)
+    db.commit()
+    db.refresh(db_process)
+    return db_process
 
 @app.delete("/processes/{process_id}")
-def delete_legal_process(process_id: int):
-    for index, process in enumerate(db_legal_processes):
-        if process.id == process_id:
-            db_legal_processes.pop(index)
-            return {"message": "Legal process deleted successfully"}
-    raise HTTPException(status_code=404, detail="Legal process not found")
+def delete_legal_process(process_id: int, db: Session = Depends(get_db)): # Adicionado db
+    # for index, process in enumerate(db_legal_processes): # Removido
+    #     if process.id == process_id: # Removido
+    #         db_legal_processes.pop(index) # Removido
+    #         return {"message": "Legal process deleted successfully"} # Removido
+    db_process = db.query(process_model.LegalProcessDB).filter(process_model.LegalProcessDB.id == process_id).first()
+    if db_process is None:
+        raise HTTPException(status_code=404, detail="Legal process not found")
+    db.delete(db_process)
+    db.commit()
+    return {"message": "Legal process deleted successfully"}

--- a/models/client.py
+++ b/models/client.py
@@ -1,17 +1,29 @@
+from sqlalchemy import Column, Integer, String
+from sqlalchemy.orm import relationship
 from pydantic import BaseModel
 
+from database import Base # Import Base from database.py
 
+# SQLAlchemy model
+class ClientDB(Base):
+    __tablename__ = "clients"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, index=True)
+    area_of_expertise = Column(String)
+
+    processes = relationship("LegalProcessDB", back_populates="client")
+
+# Pydantic models for request/response validation
 class ClientBase(BaseModel):
     name: str
     area_of_expertise: str
 
-
 class ClientCreate(ClientBase):
     pass
-
 
 class Client(ClientBase):
     id: int
 
     class Config:
-        from_attributes = True
+        from_attributes = True # Changed from orm_mode = True for Pydantic v2

--- a/models/lawyer.py
+++ b/models/lawyer.py
@@ -1,21 +1,34 @@
+from sqlalchemy import Column, Integer, String
+from sqlalchemy.orm import relationship
+from pydantic import BaseModel, EmailStr
 from typing import Optional
 
-from pydantic import BaseModel, EmailStr
+from database import Base # Import Base from database.py
 
+# SQLAlchemy model
+class LawyerDB(Base):
+    __tablename__ = "lawyers"
 
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, index=True)
+    oab = Column(String, unique=True, index=True)
+    email = Column(String, unique=True, index=True)
+    telegram_id = Column(String, nullable=True)
+
+    processes = relationship("LegalProcessDB", back_populates="lawyer")
+
+# Pydantic models for request/response validation
 class LawyerBase(BaseModel):
     name: str
     oab: str
     email: EmailStr
     telegram_id: Optional[str] = None
 
-
 class LawyerCreate(LawyerBase):
     pass
-
 
 class Lawyer(LawyerBase):
     id: int
 
     class Config:
-        from_attributes = True
+        from_attributes = True # Changed from orm_mode = True for Pydantic v2

--- a/models/legal_process.py
+++ b/models/legal_process.py
@@ -1,9 +1,30 @@
+from sqlalchemy import Column, Integer, String, Date, ForeignKey
+from sqlalchemy.orm import relationship
+from pydantic import BaseModel
 from datetime import date
 from typing import Optional
 
-from pydantic import BaseModel
+from database import Base # Import Base from database.py
 
+# SQLAlchemy model
+class LegalProcessDB(Base):
+    __tablename__ = "legal_processes"
 
+    id = Column(Integer, primary_key=True, index=True)
+    process_number = Column(String, unique=True, index=True)
+    entry_date = Column(Date)
+    delivery_deadline = Column(Date)
+    fatal_deadline = Column(Date)
+    status = Column(String, default="ativo")
+    action_type = Column(String, nullable=True)
+
+    lawyer_id = Column(Integer, ForeignKey("lawyers.id"))
+    client_id = Column(Integer, ForeignKey("clients.id"))
+
+    lawyer = relationship("LawyerDB", back_populates="processes")
+    client = relationship("ClientDB", back_populates="processes")
+
+# Pydantic models for request/response validation
 class LegalProcessBase(BaseModel):
     process_number: str
     lawyer_id: int
@@ -14,13 +35,11 @@ class LegalProcessBase(BaseModel):
     status: Optional[str] = "ativo"
     action_type: Optional[str] = None
 
-
 class LegalProcessCreate(LegalProcessBase):
     pass
-
 
 class LegalProcess(LegalProcessBase):
     id: int
 
     class Config:
-        from_attributes = True
+        from_attributes = True # Changed from orm_mode = True for Pydantic v2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ pydantic==2.5.2
 pydantic-settings==2.1.0
 python-dotenv==1.0.0
 email-validator==2.1.0.post1
+sqlalchemy==2.0.25
+psycopg2-binary==2.9.9


### PR DESCRIPTION
Este commit introduz o SQLAlchemy para substituir o armazenamento de dados em memória por um backend de banco de dados persistente (inicialmente configurado para SQLite, pronto para PostgreSQL).

Principais mudanças:

Adicionados sqlalchemy e psycopg2-binary ao arquivo requirements.txt.
    Criado o arquivo database.py para a configuração do engine e da session do SQLAlchemy.
    Definidos os modelos ORM do SQLAlchemy (LawyerDB, ClientDB, LegalProcessDB) no diretório models/, incluindo seus relacionamentos.
    Os modelos Pydantic foram mantidos para a validação de dados da API.
    Modificações no main.py:
        As tabelas do banco de dados são criadas na inicialização da aplicação.
        Todos os endpoints da API (operações CRUD para advogados, clientes e processos legais) agora usam as sessions do SQLAlchemy para interagir com o banco de dados.
        As listas em memória e os contadores de ID foram removidos.
        A lógica para validar chaves estrangeiras (lawyer_id, client_id) e verificar a existência de processos associados antes da exclusão agora consulta diretamente o banco de dados.