### PR TITLE
docs: Adiciona nota sobre dependências de compilação do mysqlclient

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ Aplicação web para um escritório de advocacia especializado no setor de energ
     pip install -r requirements.txt
     ```
 
+    **Nota sobre a instalação do `mysqlclient` em Linux:**
+    Se você encontrar erros durante a instalação do `mysqlclient` (que é uma dependência no `requirements.txt`), pode ser necessário instalar algumas bibliotecas de desenvolvimento do sistema. Para sistemas baseados em Debian/Ubuntu, tente:
+    ```bash
+    sudo apt update
+    sudo apt install python3-dev default-libmysqlclient-dev
+    ```
+    Para outras distribuições Linux ou macOS, você pode precisar de pacotes equivalentes (ex: `python3-devel`, `mysql-devel`, `mariadb-devel` ou `mariadb-connector-c-devel`). Consulte a documentação da sua distribuição ou do `mysqlclient` se o problema persistir.
+
 ## Configuração do Banco de Dados
 
 A aplicação utiliza MySQL como o banco de dados padrão.


### PR DESCRIPTION
Atualiza o README.md para incluir uma nota importante na seção "Configuração do Ambiente". Esta nota informa aos usuários de Linux sobre a possível necessidade de instalar pacotes de desenvolvimento do sistema, como `python3-dev` e `default-libmysqlclient-dev` (ou equivalentes), para a instalação bem-sucedida da dependência `mysqlclient`.