### PR TITLE
This commit establishes PyMySQL as the default and definitive Python …

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,9 +2,9 @@
 # Copie este arquivo para .env e substitua os valores pelos seus.
 # O arquivo .env NÃO DEVE ser comitado no Git.
 
-# URL de conexão para o banco de dados MySQL usando mysqlclient
-# Formato: mysql+mysqlclient://USUARIO:SENHA@HOST:PORTA/NOME_DO_BANCO
-DATABASE_URL="mysql+mysqlclient://user:password@localhost:3306/mydatabase"
+# URL de conexão para o banco de dados MySQL usando PyMySQL
+# Formato: mysql+pymysql://USUARIO:SENHA@HOST:PORTA/NOME_DO_BANCO
+DATABASE_URL="mysql+pymysql://user:password@localhost:3306/mydatabase"
 
 # Outras variáveis de ambiente do projeto podem ser adicionadas aqui no futuro.
 # Exemplo:

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Aplicação web para um escritório de advocacia especializado no setor de energ
     *   Python 3.10+
     *   FastAPI: Framework web para construção da API.
     *   SQLAlchemy: ORM para interação com o banco de dados.
-    *   mysqlclient: Driver Python para MySQL.
+    *   PyMySQL: Driver Python puro para MySQL.
     *   Uvicorn: Servidor ASGI para FastAPI.
     *   Pydantic: Para validação de dados.
 *   **Banco de Dados:**
-    *   MySQL: Banco de dados padrão da aplicação (requer configuração via arquivo `.env` e driver `mysqlclient`).
+    *   MySQL: Banco de dados padrão da aplicação (requer configuração via arquivo `.env` e driver `PyMySQL`).
     *   SQLite: Pode ser usado como alternativa para desenvolvimento local rápido (requer modificação manual em `database.py` e instalação do driver apropriado se não for o `sqlite3` embutido).
 *   **Frontend (Interface de Teste):**
     *   HTML5
@@ -55,14 +55,6 @@ Aplicação web para um escritório de advocacia especializado no setor de energ
     ```bash
     pip install -r requirements.txt
     ```
-
-    **Nota sobre a instalação do `mysqlclient` em Linux:**
-    Se você encontrar erros durante a instalação do `mysqlclient` (que é uma dependência no `requirements.txt`), pode ser necessário instalar algumas bibliotecas de desenvolvimento do sistema. Para sistemas baseados em Debian/Ubuntu, tente:
-    ```bash
-    sudo apt update
-    sudo apt install python3-dev default-libmysqlclient-dev
-    ```
-    Para outras distribuições Linux ou macOS, você pode precisar de pacotes equivalentes (ex: `python3-devel`, `mysql-devel`, `mariadb-devel` ou `mariadb-connector-c-devel`). Consulte a documentação da sua distribuição ou do `mysqlclient` se o problema persistir.
 
 ## Configuração do Banco de Dados
 
@@ -161,10 +153,10 @@ Com o MySQL Server instalado e configurado conforme o guia acima, siga os próxi
 
 2.  **Configure a `DATABASE_URL` no arquivo `.env`:**
     Abra o arquivo `.env` e edite a variável `DATABASE_URL` com as credenciais do usuário e banco de dados que você criou no MySQL (conforme o "Guia Rápido" acima, por exemplo, `myuser`, `mypassword`, `mydatabase`).
-    O formato é: `mysql+mysqlclient://USUARIO:SENHA@HOST:PORTA/NOME_DO_BANCO`
+    O formato é: `mysql+pymysql://USUARIO:SENHA@HOST:PORTA/NOME_DO_BANCO`
     Exemplo (usando os dados do guia):
     ```env
-    DATABASE_URL="mysql+mysqlclient://myuser:mypassword@localhost:3306/mydatabase"
+    DATABASE_URL="mysql+pymysql://myuser:mypassword@localhost:3306/mydatabase"
     ```
     A aplicação irá falhar ao iniciar se esta variável não estiver corretamente configurada.
 

--- a/database.py
+++ b/database.py
@@ -12,13 +12,13 @@ if DATABASE_URL is None:
     raise EnvironmentError(
         "Erro crítico: A variável de ambiente DATABASE_URL não está definida.\n"
         "Para configurar o MySQL, crie um arquivo '.env' na raiz do projeto "\
-        "e adicione a linha no formato: DATABASE_URL=\"mysql+mysqlclient://user:password@host:port/dbname\"\n"
+        "e adicione a linha no formato: DATABASE_URL=\"mysql+pymysql://user:password@host:port/dbname\"\n"
         "Substitua 'user', 'password', 'host', 'port', e 'dbname' com suas credenciais reais do MySQL.\n"
         "Consulte o README.md e o .env.example para mais detalhes."
     )
 
-# Para MySQL com mysqlclient, não são necessários connect_args especiais como o check_same_thread do SQLite.
-# A engine SQLAlchemy identificará o dialeto mysql+mysqlclient a partir da URL.
+# Para MySQL com PyMySQL, não são necessários connect_args especiais como o check_same_thread do SQLite.
+# A engine SQLAlchemy identificará o dialeto mysql+pymysql a partir da URL.
 engine = create_engine(DATABASE_URL)
 
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ pydantic-settings==2.1.0
 python-dotenv==1.0.0
 email-validator==2.1.0.post1
 sqlalchemy==2.0.25
-mysqlclient==2.2.0
+PyMySQL==1.1.0


### PR DESCRIPTION
…driver para interações com o banco de dados MySQL, **substituindo o `mysqlclient`**.

O PyMySQL, sendo um **driver puramente Python**, visa simplificar a instalação e evitar problemas de compilação em diferentes ambientes.

**Alterações:**

* **`requirements.txt`**:
    * Removido `mysqlclient` (se presente).
    * Adicionado `PyMySQL`.
* **`.env.example`**:
    * Exemplo de `DATABASE_URL` atualizado para `mysql+pymysql://...`.
    * Comentários ajustados para PyMySQL.
* **`database.py`**:
    * Mensagem de erro para `DATABASE_URL` ausente atualizada para mencionar o formato `mysql+pymysql://...`.
    * Comentários internos ajustados para PyMySQL.
* **`README.md`**:
    * Referências a `mysqlclient` alteradas para `PyMySQL`.
    * Formato do exemplo de `DATABASE_URL` atualizado para `mysql+pymysql`.
    - Removed the note about `mysqlclient` compilation dependencies, as it's not relevant for PyMySQL.