### PR TITLE
fix: Especifica comprimento para colunas String nos modelos SQLAlchemy

### DIFF
--- a/models/client.py
+++ b/models/client.py
@@ -9,8 +9,8 @@ class ClientDB(Base):
     __tablename__ = "clients"
 
     id = Column(Integer, primary_key=True, index=True)
-    name = Column(String, index=True)
-    area_of_expertise = Column(String)
+    name = Column(String(150), index=True)  # Comprimento 150
+    area_of_expertise = Column(String(100)) # Comprimento 100
 
     processes = relationship("LegalProcessDB", back_populates="client")
 

--- a/models/lawyer.py
+++ b/models/lawyer.py
@@ -10,10 +10,10 @@ class LawyerDB(Base):
     __tablename__ = "lawyers"
 
     id = Column(Integer, primary_key=True, index=True)
-    name = Column(String, index=True)
-    oab = Column(String, unique=True, index=True)
-    email = Column(String, unique=True, index=True)
-    telegram_id = Column(String, nullable=True)
+    name = Column(String(100), index=True)  # Comprimento 100
+    oab = Column(String(20), unique=True, index=True) # Comprimento 20
+    email = Column(String(100), unique=True, index=True) # Comprimento 100
+    telegram_id = Column(String(50), nullable=True) # Comprimento 50
 
     processes = relationship("LegalProcessDB", back_populates="lawyer")
 

--- a/models/legal_process.py
+++ b/models/legal_process.py
@@ -11,12 +11,12 @@ class LegalProcessDB(Base):
     __tablename__ = "legal_processes"
 
     id = Column(Integer, primary_key=True, index=True)
-    process_number = Column(String, unique=True, index=True)
+    process_number = Column(String(50), unique=True, index=True) # Comprimento 50
     entry_date = Column(Date)
     delivery_deadline = Column(Date)
     fatal_deadline = Column(Date)
-    status = Column(String, default="ativo")
-    action_type = Column(String, nullable=True)
+    status = Column(String(30), default="ativo") # Comprimento 30
+    action_type = Column(String(100), nullable=True) # Comprimento 100
 
     lawyer_id = Column(Integer, ForeignKey("lawyers.id"))
     client_id = Column(Integer, ForeignKey("clients.id"))


### PR DESCRIPTION
Adiciona o parâmetro de comprimento (ex: String(100)) a todas as colunas do tipo `sqlalchemy.String` nos modelos ORM (LawyerDB, ClientDB, LegalProcessDB).

Esta alteração é necessária para compatibilidade com o dialeto MySQL, que exige que colunas VARCHAR tenham um comprimento máximo definido, resolvendo o erro `sqlalchemy.exc.CompileError: VARCHAR requires a length on dialect mysql`.