### PR TITLE
I've reverted the Pydantic validators to strict mode as we discussed.

### DIFF
--- a/models/client.py
+++ b/models/client.py
@@ -1,8 +1,8 @@
 from sqlalchemy import Column, Integer, String, Enum as SQLAlchemyEnum
 from sqlalchemy.orm import relationship
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel
 import enum
-import logging
+# logging and field_validator removed as they are no longer used
 
 from database import Base # Import Base from database.py
 
@@ -28,17 +28,6 @@ class ClientDB(Base):
 class ClientBase(BaseModel):
     name: str
     area_of_expertise: AreaOfExpertiseEnum
-
-    @field_validator('area_of_expertise', mode='before')
-    @classmethod
-    def validate_area_of_expertise_enum(cls, value):
-        if value is None: # Allow None if the field is Optional, though current model is not Optional
-            return None
-        try:
-            return AreaOfExpertiseEnum(value)
-        except ValueError:
-            logging.warning(f"Invalid area_of_expertise value found: '{value}'. Returning None instead for diagnosis.")
-            return None
 
 class ClientCreate(ClientBase):
     pass

--- a/models/lawyer.py
+++ b/models/lawyer.py
@@ -32,8 +32,10 @@ class LawyerBase(BaseModel):
         if value is None:
             return value
         if not re.match(r"^@[a-zA-Z0-9_]{3,31}$", value): # Usernames 3-31 chars after @
-            logging.warning(f"Invalid telegram_id format found: '{value}'. Returning None instead.")
-            return None
+            raise ValueError(
+                "ID do Telegram inválido. Deve começar com '@' seguido por 3 a 31 "
+                "caracteres alfanuméricos ou underscores (ex: @usuario123)."
+            )
         return value
 
     @field_validator('oab')
@@ -55,8 +57,9 @@ class LawyerBase(BaseModel):
         value_upper = value.upper()
 
         if not (re.match(pattern_num_uf, value_upper) or re.match(pattern_num_barra_uf, value_upper)):
-            logging.warning(f"Invalid OAB format found: '{value}'. Returning original value for diagnosis.")
-            return value # Returning original value 'value' as per instruction, or value_upper
+            raise ValueError(
+                "Formato da OAB inválido. Use formatos como '12345SP', '123.456SP', ou '12345/SP'."
+            )
 
         # Normaliza removendo o ponto para armazenamento, se presente no primeiro padrão
         if '.' in value_upper and '/' not in value_upper:


### PR DESCRIPTION
Eu reverti os validadores Pydantic para o modo estrito, como havíamos discutido:

    Restaurado o comportamento original das funções validate_oab e validate_telegram_id em models/lawyer.py. Elas agora lançarão um ValueError se encontrarem formatos inválidos.
    Removido o validador de diagnóstico para area_of_expertise em models/client.py. Este campo agora será estritamente validado pelo Pydantic, seguindo as regras de AreaOfExpertiseEnum.

Isso assume que você fará a limpeza dos dados problemáticos no banco de dados que estavam gerando os erros 500, conforme identificamos anteriormente.