### PR TITLE
fix: Add missing Optional import in legal_process.py

### DIFF
--- a/models/legal_process.py
+++ b/models/legal_process.py
@@ -2,7 +2,7 @@ from sqlalchemy import Column, Integer, String, Date, ForeignKey
 from sqlalchemy.orm import relationship
 from pydantic import BaseModel, field_validator
 from datetime import date, datetime # Adicionado datetime para strptime
-from typing import Any, Union # Union para o tipo de retorno do validador
+from typing import Any, Union, Optional # Adicionado Optional
 
 from database import Base # Importa Base de database.py
 


### PR DESCRIPTION
fix: Adição de Optional Faltante em legal_process.py

Esta correção resolve um NameError em models/legal_process.py ao adicionar from typing import Optional. Essa importação estava ausente para as dicas de tipo usadas nos modelos Pydantic (por exemplo, status: Optional[str]).