### PR TITLE
fix: Update date validator syntax for Pydantic V1 compatibility

### DIFF
--- a/models/legal_process.py
+++ b/models/legal_process.py
@@ -1,6 +1,6 @@
 from sqlalchemy import Column, Integer, String, Date, ForeignKey
 from sqlalchemy.orm import relationship
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, validator # Alterado de field_validator para validator
 from datetime import date, datetime # Adicionado datetime para strptime
 from typing import Any, Union, Optional # Adicionado Optional
 
@@ -36,8 +36,8 @@ class LegalProcessBase(BaseModel):
     status: Optional[str] = "ativo"
     action_type: Optional[str] = None
 
-    # Validador para converter datas de string "dd/mm/aaaa" para objetos date
-    @field_validator('entry_date', 'delivery_deadline', 'fatal_deadline', pre=True)
+    # Validador para converter datas de string "dd/mm/aaaa" para objetos date (Sintaxe Pydantic V1)
+    @validator('entry_date', 'delivery_deadline', 'fatal_deadline', pre=True, always=True)
     @classmethod
     def parse_date_format(cls, value: Any) -> Union[date, Any]:
         # Verifica se o valor é uma string no formato "dd/mm/aaaa"


### PR DESCRIPTION
fix: Atualização da Sintaxe do Validador de Data para Compatibilidade com Pydantic V1

Esta correção soluciona um TypeError em models/legal_process.py relacionado ao argumento pre do field_validator.

As mudanças incluem:

    Substituição de field_validator pelo validator do Pydantic V1.
    Atualização do decorator para @validator('entry_date', 'delivery_deadline', 'fatal_deadline', pre=True, always=True).
    Ajuste da importação de pydantic conforme necessário.

Isso deve garantir a compatibilidade com ambientes Pydantic V1.