### PR TITLE
fix: Remove '- Teste API' from H1 title in index.html

### DIFF
--- a/static_frontend/index.html
+++ b/static_frontend/index.html
@@ -42,7 +42,7 @@
 
         <!-- Conteúdo Principal da Aplicação (inicialmente oculto) -->
         <div id="main-content" style="display:none;">
-            <h1 class="text-center my-4">Gerenciador de Processos Jurídicos - Teste API</h1>
+            <h1 class="text-center my-4">Gerenciador de Processos Jurídicos</h1>
 
             <!-- Seção de Advogados -->
             <section id="lawyers-section" class="mb-5 p-4 border rounded shadow-sm">


### PR DESCRIPTION
Este commit atualiza o título principal (H1) em static_frontend/index.html para "Gerenciador de Processos Jurídicos", removendo o sufixo "- Teste API". Essa alteração padroniza o título da página com o título global da aplicação.