### PR TITLE
feat: Display percentages in status pie chart tooltips on dashboard

### DIFF
--- a/static_frontend/dashboard.js
+++ b/static_frontend/dashboard.js
@@ -357,7 +357,24 @@ function renderCharts() {
             data: statusData.data,
             backgroundColor: ['#0d6efd', '#198754', '#ffc107', '#dc3545', '#6c757d', '#adb5bd'], // Cores Bootstrap
         }]
-    }, { responsive: true, maintainAspectRatio: false });
+    }, {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+            tooltip: {
+                callbacks: {
+                    label: function(tooltipItem) {
+                        const dataset = tooltipItem.dataset;
+                        const currentValue = dataset.data[tooltipItem.dataIndex];
+                        const total = dataset.data.reduce((acc, value) => acc + value, 0);
+                        const percentage = ((currentValue / total) * 100).toFixed(2);
+                        // tooltipItem.label é o nome da fatia (e.g., 'Ativo')
+                        return `${tooltipItem.label}: ${currentValue} (${percentage}%)`;
+                    }
+                }
+            }
+        }
+    });
 
     // Gráfico de Advogados
     const lawyerData = processDataForLawyerChart(allProcesses, lawyerMap);


### PR DESCRIPTION
Este commit atualiza o gráfico de pizza "Processos por Status" em static_frontend/dashboard.js para exibir porcentagens nas dicas de ferramentas (tooltips).

As opções do Chart.js para este gráfico foram modificadas com um callback de tooltip personalizado, que agora calcula e mostra a porcentagem para cada fatia, juntamente com seu valor absoluto e rótulo.