### PR TITLE
feat: Add 'data_conclusao_real' for legal processes

### DIFF
--- a/models/legal_process.py
+++ b/models/legal_process.py
@@ -15,6 +15,7 @@ class LegalProcessDB(Base):
     entry_date = Column(Date)
     delivery_deadline = Column(Date)
     fatal_deadline = Column(Date)
+    data_conclusao_real = Column(Date, nullable=True) # Novo campo
     status = Column(String(30), default="ativo") # Comprimento 30
     action_type = Column(String(100), nullable=True) # Comprimento 100
 
@@ -33,11 +34,12 @@ class LegalProcessBase(BaseModel):
     entry_date: date
     delivery_deadline: date
     fatal_deadline: date
+    data_conclusao_real: Optional[date] = None # Novo campo Pydantic
     status: Optional[str] = "ativo"
     action_type: Optional[str] = None
 
     # Validador para converter datas de string "dd/mm/aaaa" para objetos date (Sintaxe Pydantic V1)
-    @validator('entry_date', 'delivery_deadline', 'fatal_deadline', pre=True, always=True)
+    @validator('entry_date', 'delivery_deadline', 'fatal_deadline', 'data_conclusao_real', pre=True, always=True, check_fields=False)
     @classmethod
     def parse_date_format(cls, value: Any) -> Union[date, Any]:
         # Verifica se o valor é uma string no formato "dd/mm/aaaa"

--- a/static_frontend/index.html
+++ b/static_frontend/index.html
@@ -186,6 +186,11 @@
                                 <input type="text" class="form-control" id="process-fatal-deadline" required placeholder="dd/mm/aaaa">
                             </div>
                             <div class="mb-3">
+                                <label for="process-completion-date" class="form-label">Data de Conclusão Real:</label>
+                                <input type="text" class="form-control" id="process-completion-date" placeholder="dd/mm/aaaa">
+                                <div class="invalid-feedback" id="process-completion-date-error"></div>
+                            </div>
+                            <div class="mb-3">
                                 <label for="process-status" class="form-label">Status:</label>
                                 <input type="text" class="form-control" id="process-status" value="ativo">
                                 <div class="invalid-feedback" id="process-status-error"></div>


### PR DESCRIPTION
Este commit introduz o campo data_conclusao_real (data de conclusão real) à estrutura de dados dos processos jurídicos. Essa adição é crucial para futuras análises baseadas em IA sobre atrasos em processos.

As mudanças incluem:
1. Backend (models/legal_process.py)

    Adicionado data_conclusao_real = Column(Date, nullable=True) ao modelo SQLAlchemy LegalProcessDB.
    Incluído data_conclusao_real: Optional[date] = None nos modelos Pydantic (LegalProcessBase, LegalProcessCreate, LegalProcess).
    O validador de data do Pydantic (parse_date_format) foi atualizado para incluir data_conclusao_real, permitindo o formato de entrada "dd/mm/aaaa".

2. Alimentação do Banco de Dados (seed_db.py)

    O arquivo seed_db.py foi modificado para preencher data_conclusao_real para processos com status "concluído".
    A lógica agora gera datas de conclusão tanto dentro quanto após o fatal_deadline para simular conclusões dentro do prazo e com atraso.

3. Frontend (static_frontend/index.html & static_frontend/script.js)

    Adicionado um campo de entrada para "Data de Conclusão Real" (opcional, formato "dd/mm/aaaa") ao formulário de processo jurídico em index.html.
    O script.js foi atualizado para:
        Exibir data_conclusao_real (formatado) na lista de processos.
        Preencher o novo campo ao editar um processo.
        Incluir data_conclusao_real (analisado de "dd/mm/aaaa" para "aaaa-mm-dd" ou nulo) ao criar/atualizar processos.
        Adicionada validação no lado do cliente para o formato e consistência lógica deste novo campo de data.