### PR TITLE
fix: Adjust datalabel offset in action type chart on dashboard

### DIFF
--- a/static_frontend/dashboard.js
+++ b/static_frontend/dashboard.js
@@ -406,6 +406,7 @@ function renderLawyerChart() {
             datalabels: {
                 anchor: 'end',
                 align: 'top',
+                offset: 8, // Adicionado para dar espaço
                 formatter: (value, ctx) => value,
                 color: '#333'
             }


### PR DESCRIPTION
Este commit modifica a configuração de plugins.datalabels para o gráfico de barras "Processos por Tipo de Ação" em static_frontend/dashboard.js.

Foi adicionado um offset: 8 aos datalabels para proporcionar um espaçamento vertical maior entre o topo da barra e o valor exibido. Essa alteração resolve um problema visual onde o rótulo poderia colidir com outros elementos do gráfico ou com o próprio texto.