### PR TITLE
feat: Conversão de Gráficos de Barras para Horizontal no Dashboard para Melhor Leitura

### DIFF
--- a/static_frontend/dashboard.js
+++ b/static_frontend/dashboard.js
@@ -399,16 +399,24 @@ function renderLawyerChart() {
     console.log('[Dashboard Debug] Renderizando/Atualizando Lawyer Chart...');
     const lawyerData = processDataForLawyerChart(allProcesses, lawyerMap);
     const options = {
+        indexAxis: 'y', // Define como gráfico de barras horizontais
         responsive: true,
         maintainAspectRatio: false,
-        scales: { y: { beginAtZero: true, ticks: { stepSize: 1 } } },
+        scales: {
+            x: { // O eixo de valores agora é X
+                beginAtZero: true,
+                ticks: {
+                    stepSize: 1
+                }
+            }
+        },
         plugins: {
             datalabels: {
                 anchor: 'end',
-                align: 'top',
-                offset: 8, // Adicionado para dar espaço
-                formatter: (value, ctx) => value,
-                color: '#333'
+                align: 'right',
+                offset: -4, // Ajusta para dentro da barra
+                color: '#fff', // Cor do texto do datalabel
+                formatter: (value, ctx) => value
             }
         }
     };
@@ -427,15 +435,24 @@ function renderActionTypeChart() {
     console.log('[Dashboard Debug] Renderizando/Atualizando Action Type Chart...');
     const actionTypeData = processDataForActionTypeChart(allProcesses);
     const options = {
+        indexAxis: 'y', // Define como gráfico de barras horizontais
         responsive: true,
         maintainAspectRatio: false,
-        scales: { y: { beginAtZero: true, ticks: { stepSize: 1 } } },
+        scales: {
+            x: { // O eixo de valores agora é X
+                beginAtZero: true,
+                ticks: {
+                    stepSize: 1
+                }
+            }
+        },
         plugins: {
             datalabels: {
                 anchor: 'end',
-                align: 'top',
-                formatter: (value, ctx) => value,
-                color: '#333'
+                align: 'right',
+                offset: -4, // Ajusta para dentro da barra
+                color: '#fff', // Cor do texto do datalabel
+                formatter: (value, ctx) => value
             }
         }
     };


### PR DESCRIPTION
Este commit modifica os gráficos de barras "Processos por Advogado" e "Processos por Tipo de Ação" em static_frontend/dashboard.js para se tornarem horizontais.

As mudanças incluem:

    Definição de indexAxis: 'y' nas opções do gráfico.
    Ajuste das scales para x no eixo de valores.
    Atualização da configuração dos datalabels (align, offset, color) para uma exibição otimizada nas barras horizontais.

Essa alteração visa melhorar a legibilidade quando há muitas categorias.