### PR TITLE
refactor: Ocultar Datalabels em Gráficos de Barras no Dashboard

### DIFF
--- a/static_frontend/dashboard.js
+++ b/static_frontend/dashboard.js
@@ -467,11 +467,7 @@ function renderLawyerChart() {
         },
         plugins: {
             datalabels: {
-                anchor: 'end',
-                align: 'right',
-                offset: -4, // Ajusta para dentro da barra
-                color: '#fff', // Cor do texto do datalabel
-                formatter: (value, ctx) => value
+                display: false // Oculta os datalabels para este gráfico
             }
         }
     };
@@ -503,11 +499,7 @@ function renderActionTypeChart() {
         },
         plugins: {
             datalabels: {
-                anchor: 'end',
-                align: 'right',
-                offset: -4, // Ajusta para dentro da barra
-                color: '#fff', // Cor do texto do datalabel
-                formatter: (value, ctx) => value
+                display: false // Oculta os datalabels para este gráfico
             }
         }
     };


### PR DESCRIPTION
Este commit ajusta a exibição do chartjs-plugin-datalabels para os gráficos de barras ("Processos por Advogado" e "Processos por Tipo de Ação") em static_frontend/dashboard.js.

    Os datalabels (valores exatos nas barras) para esses dois gráficos de barras agora estão ocultos ao definir plugins.datalabels.display: false. Os valores exatos continuam disponíveis nas dicas de ferramentas ao passar o mouse.
    O gráfico de pizza ("Processos por Status") continua a exibir os datalabels de porcentagem diretamente nas fatias.

Essa mudança visa reduzir a poluição visual e melhorar a legibilidade quando os gráficos de barras possuem muitas categorias, atendendo ao seu feedback sobre a "exibição com bug" dos números.