### PR TITLE
Fix: Ajuste de Validadores e Dados de Teste para OAB e ID do Telegram

### DIFF
--- a/models/lawyer.py
+++ b/models/lawyer.py
@@ -47,13 +47,20 @@ class LawyerBase(BaseModel):
     @classmethod
     def validate_telegram_id(cls, value: Optional[str]) -> Optional[str]:
         if value is None:
+            return None # Retorna None explicitamente se o valor for None
+
+        # Verifica se é um ID numérico (Chat ID)
+        if re.match(r"^-?\d+$", value): # Permite IDs negativos para grupos/canais e positivos para usuários
             return value
-        if not re.match(r"^@[a-zA-Z0-9_]{3,31}$", value): # Usernames de 3 a 31 caracteres após @
-            raise ValueError(
-                "ID do Telegram inválido. Deve começar com '@' seguido por 3 a 31 "
-                "caracteres alfanuméricos ou underscores (ex: @usuario123)."
-            )
-        return value
+
+        # Verifica se é um username no formato @username
+        if re.match(r"^@[a-zA-Z0-9_]{3,31}$", value):
+            return value
+
+        raise ValueError(
+            "ID do Telegram inválido. Deve ser um ID numérico ou um username no formato '@usuario' "
+            "(3 a 31 caracteres alfanuméricos ou underscores)."
+        )
 
     @field_validator('oab')
     @classmethod

--- a/teste_telegram_notifications.py
+++ b/teste_telegram_notifications.py
@@ -42,7 +42,7 @@ except ValueError:
     APP_TELEGRAM_ADVANCE_NOTIFICATION_DAYS = 5
 
 # Constantes para dados de teste
-TEST_LAWYER_OAB = "TEST001TG"
+TEST_LAWYER_OAB = "TEST01SP" # OAB de teste corrigida para formato válido
 TEST_LAWYER_EMAIL = "telegram_tester@example.com"
 TEST_LAWYER_NAME = "Advogado Teste Telegram"
 TEST_CLIENT_NAME = "Cliente Teste Notificações" # Nome mais genérico


### PR DESCRIPTION
Este commit foca em resolver problemas de validação, permitindo que o sistema aceite formatos mais flexíveis e garantindo que os dados de teste estejam corretos.

As mudanças incluem:

    Validador de telegram_id em models/lawyer.py: Agora, o validador aceita IDs de chat numéricos em formato de string, além do formato @username já existente. Essa flexibilidade é importante para acomodar diferentes tipos de identificadores do Telegram.
    Correção de TEST_LAWYER_OAB em teste_telegram_notifications.py: O OAB do advogado de teste foi ajustado para usar uma UF ('SP') válida. Isso resolve o ResponseValidationError que ocorria ao tentar buscar a lista de advogados após o login, que era causado por dados de teste que não passavam na validação do Pydantic.

Essas alterações garantem que o sistema seja mais robusto ao lidar com diferentes formatos de entrada e que os testes de notificação funcionem corretamente.