### PR TITLE
Fix: Ajuste do Validador de OAB e Dados de Teste para Resolver Problema de Login

### DIFF
--- a/teste_telegram_notifications.py
+++ b/teste_telegram_notifications.py
@@ -42,7 +42,7 @@ except ValueError:
     APP_TELEGRAM_ADVANCE_NOTIFICATION_DAYS = 5
 
 # Constantes para dados de teste
-TEST_LAWYER_OAB = "TEST01SP" # OAB de teste corrigida para formato válido
+TEST_LAWYER_OAB = "99901SP" # OAB de teste corrigida para formato numérico válido
 TEST_LAWYER_EMAIL = "telegram_tester@example.com"
 TEST_LAWYER_NAME = "Advogado Teste Telegram"
 TEST_CLIENT_NAME = "Cliente Teste Notificações" # Nome mais genérico


### PR DESCRIPTION
Este commit resolve um problema crítico de validação que impedia o login e a correta exibição da lista de advogados.

As mudanças incluem:

    Validador de OAB em models/lawyer.py: O validador foi modificado para processar corretamente OABs puramente numéricas (com 1 a 6 dígitos) seguidas de uma UF. Além disso, ele agora normaliza formatos que contêm pontos, removendo-os para garantir consistência.
    Atualização do TEST_LAWYER_OAB em teste_telegram_notifications.py: O OAB de teste foi alterado para 99901SP para se adequar às novas regras de validação.

Essas alterações garantem que formatos de OAB como o do administrador (00001SP) e os dados de teste passem pela validação do Pydantic, resolvendo o ResponseValidationError que ocorria após o login ao buscar a lista de advogados.