### PR TITLE
Feat: Adição de Rolagem Vertical aos Gráficos do Dashboard

### DIFF
--- a/static_frontend/dashboard.css
+++ b/static_frontend/dashboard.css
@@ -90,3 +90,9 @@ h4 {
     max-height: 500px; /* Define uma altura máxima. Ajuste conforme necessário. */
     overflow-y: auto;  /* Mostra a barra de scroll vertical apenas se o conteúdo exceder max-height */
 }
+
+.chart-scroll-container {
+    max-height: 400px; /* Altura máxima antes da rolagem */
+    overflow-y: auto;  /* Adiciona barra de rolagem vertical se necessário */
+    position: relative; /* Necessário para que o Chart.js funcione bem com tooltips em contêineres de rolagem */
+}

--- a/static_frontend/dashboard.html
+++ b/static_frontend/dashboard.html
@@ -236,7 +236,9 @@
                                     <h6 class="m-0 font-weight-bold text-primary">Processos por Advogado</h6>
                                 </div>
                                 <div class="card-body">
-                                    <canvas id="lawyer-chart"></canvas>
+                                    <div class="chart-scroll-container">
+                                        <canvas id="lawyer-chart"></canvas>
+                                    </div>
                                 </div>
                             </div>
                         </div>
@@ -246,7 +248,9 @@
                                     <h6 class="m-0 font-weight-bold text-primary">Processos por Tipo de Ação</h6>
                                 </div>
                                 <div class="card-body">
-                                    <canvas id="action-type-chart"></canvas>
+                                    <div class="chart-scroll-container">
+                                        <canvas id="action-type-chart"></canvas>
+                                    </div>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
Este commit implementa uma melhoria visual importante no dashboard: os gráficos 'Processos por Advogado' e 'Processos por Tipo de Ação' agora contam com barras de rolagem verticais.

Para isso, os gráficos foram envolvidos em contêineres roláveis. Regras CSS foram aplicadas a esses contêineres para definir uma altura máxima e habilitar a rolagem vertical (overflow-y: auto) quando o conteúdo do gráfico excede essa altura.

Essa mudança impede que os gráficos se tornem excessivamente altos e comprometam o layout da página ao exibir um grande número de advogados ou tipos de ação.